### PR TITLE
chore(dependabot): ungroup updates and cap PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,16 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
-    groups:
-      docusaurus:
-        patterns:
-          - "@docusaurus/*"
-      search:
-        patterns:
-          - "@easyops-cn/*"
+    open-pull-requests-limit: 5
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,10 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 5
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,11 @@ name: CI
 on:
   push:
     branches:
-      - 1.x
+      - main
 
   pull_request:
     branches:
-      - 1.x
+      - main
 
 jobs:
   validate:


### PR DESCRIPTION
## Summary
- remove grouped Dependabot updates for npm
- cap open Dependabot PRs at 5 for npm and github-actions
- change Dependabot checks from weekly to monthly for both ecosystems
- run CI on pushes to main and pull requests targeting main

## Behavior Change
Dependabot will open individual PRs per dependency update instead of grouped npm batches, each ecosystem will stop at 5 open PRs, and update checks will run monthly instead of weekly.

## Review Focus
- confirm the Dependabot config changed only in the intended fields
- confirm the CI workflow now targets main instead of 1.x

## Notes
Closes #27